### PR TITLE
(#172) Add ';' as separator for commands in console

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -321,7 +321,15 @@ int Console::parseCommand(QStringList &args) {
 void Console::parse(QStringList &args) {
     QStringList command;
     for (int i = 0; i < args.count(); ++i) {
-        if (args[i] == "&&") {
+        if (args[i][args[i].count() - 1] == ';') {
+            QString word = args[i];
+            word.chop(1);
+            if (word.count()) {
+                command.append(word);
+            }
+            parseCommand(command);
+            command.clear();
+        } else if (args[i] == "&&") {
             int retCode = parseCommand(command);
             command.clear();
             if (retCode != 0) {


### PR DESCRIPTION
close #172 