### PR TITLE
(#114, #372) Add instructions for Windows deployment and building in Qt Creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ $ cmake .. -DCMAKE_PREFIX_PATH="/path/to/qt/"
 $ cmake --build .
 $ ./bin/fishing-time
 ```
+
+### Create standalone build
+fishing-time build depends on Qt runtime. In order to include this runtime into the build and be able to run this executable on different machines you need to perform the following steps:
+
+#### Windows
+
+```console
+$ mkdir build
+$ cd build
+$ cmake .. -DCMAKE_PREFIX_PATH="path\to\qt\"
+$ cmake --build . --config Release
+$ path\to\qt\bin\windeployqt.exe bin\fishing-time.exe --release --compiler-runtime --force --no-translations
+```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 ### Build and run
 
+#### CMake
+
 ```console
 $ mkdir build
 $ cd build
@@ -17,6 +19,13 @@ $ cmake .. -DCMAKE_PREFIX_PATH="/path/to/qt/"
 $ cmake --build .
 $ ./bin/fishing-time
 ```
+
+#### QtCreator
+
+1. Open QtCreator
+1. `File > Open File or Project...` and select file CMakeLists.txt
+1. Select at least one configuration option and press "Configure Project"
+1. Wait until configuration is finished and press "Play" button (Ctrl + R)
 
 ### Create standalone build
 fishing-time build depends on Qt runtime. In order to include this runtime into the build and be able to run this executable on different machines you need to perform the following steps:


### PR DESCRIPTION
close #114 
close #372 